### PR TITLE
 Replaced calls deprecated since Mojolicious 5: static, content, exception.

### DIFF
--- a/twitter_rss_blocking.pl
+++ b/twitter_rss_blocking.pl
@@ -30,7 +30,7 @@ helper heavy_users => sub {
 helper parse_tweet => sub {
   my ($self, $dom) = @_;
 
-  my $body = $dom->at('p.tweet-text')->content_xml;
+  my $body = $dom->at('p.tweet-text')->content;
   $body = "<![CDATA[$body]]>";
 
   my $header    = $dom->at('div.stream-item-header');
@@ -55,7 +55,7 @@ helper parse_tweet => sub {
   }
 };
 
-any '/' => sub { shift->render_static( 'index.html' ) };
+any '/' => sub { shift->reply->static( 'index.html' ) };
 
 get '/twitter_user_to_rss' => sub {
   my $self = shift;
@@ -74,7 +74,7 @@ get '/twitter_user_to_rss' => sub {
 
   my $tx = $self->ua->get($url);
   unless ($tx->success) { 
-    return $self->render_exception(scalar $tx->error);
+    return $self->reply->exception(scalar $tx->error);
   }
 
   my $tweets = $tx->res->dom('li.js-stream-item .tweet .content');

--- a/twitter_rss_nonblocking.pl
+++ b/twitter_rss_nonblocking.pl
@@ -76,7 +76,7 @@ get '/twitter_user_to_rss' => sub {
   my $tx = $self->ua->get($url, sub {
     my ($ua, $tx) = @_;
     unless ($tx->success) { 
-      return $self->render_exception(scalar $tx->error);
+      return $self->reply->exception(scalar $tx->error);
     }
 
     my $tweets = $tx->res->dom('li.js-stream-item .tweet .content');

--- a/twitter_rss_nonblocking.pl
+++ b/twitter_rss_nonblocking.pl
@@ -30,7 +30,7 @@ helper heavy_users => sub {
 helper parse_tweet => sub {
   my ($self, $dom) = @_;
 
-  my $body = $dom->at('p.tweet-text')->content_xml;
+  my $body = $dom->at('p.tweet-text')->content;
   $body = "<![CDATA[$body]]>";
 
   my $header    = $dom->at('div.stream-item-header');
@@ -55,7 +55,7 @@ helper parse_tweet => sub {
   }
 };
 
-any '/' => sub { shift->render_static( 'index.html' ) };
+any '/' => sub { shift->reply->static( 'index.html' ) };
 
 get '/twitter_user_to_rss' => sub {
   my $self = shift;


### PR DESCRIPTION
Per deprecation / replacement notes at https://github.com/kraih/mojo/blob/master/Changes −

content_xml → content
render_static → reply->static
render_exception → reply->exception
